### PR TITLE
Put initialization and exit into states

### DIFF
--- a/finite_state_machine.c
+++ b/finite_state_machine.c
@@ -5,17 +5,21 @@
 
 enum state fsm_run(enum state current_state) {
 	
-	/*
-	Kode som bare gjennomføres én gang i overgangene mellom tilstandene, kjøres i "fsm_trans" funksjonene
-	Kode som må kjøres kontinuerlig mens heisen er i en tilstand, kjøres i casene
-	*/
+	//Kode som bare gjennomføres én gang i overgangene mellom tilstandene, kjøres i "fsm_trans" funksjonene
+	//Kode som må kjøres kontinuerlig mens heisen er i en tilstand, kjøres i casene
 
 	switch (current_state) {
 
-	case(start):
-		fsm_trans_start_calibration();
-		next_state = calibrating;
+	case(initialize):
+		if (!elev_init()) { 									//Initialiser maskinvare
+			printf("Unable to initialize elevator hardware!\n");
+			next_state = exit;
+		}
+		else{
+			fsm_trans_start_calibration();
+			next_state = calibrating;
 		break;
+		}
 
 	case(calibrating):
 		if(elev_get_floor_sensor_signal() >= 0) {
@@ -98,6 +102,7 @@ enum state fsm_run(enum state current_state) {
 		}
 		break;
 	}
+
 	return next_state;
 }
 

--- a/finite_state_machine.h
+++ b/finite_state_machine.h
@@ -1,12 +1,13 @@
 //De ulike tilstandene til heisen
 enum state {
-	start,
+	initialize,
 	calibrating,
 	door_closed,
 	door_open,
 	fulfilling_order,
 	em_stop_anywhere,
-	em_stop_at_floor
+	em_stop_at_floor,
+	exit				//ikke implementert som en case - programmet avsluttes fra main med en gang current_state == exit;
 };
 
 //Variabler

--- a/main.c
+++ b/main.c
@@ -3,18 +3,13 @@
 #include "finite_state_machine.h"
 #include "order_overview.h"
 
-enum state current_state = start;
+enum state current_state = initialize;
 
 int main() {
-    //Initialiser maskinvare
-    if (!elev_init()) {
-        printf("Unable to initialize elevator hardware!\n");
-        return 1;
-    }
-    
-    //Hovedloop
-    while (1) {
+
+    while (current_state != exit) {
 	    current_state = fsm_run(current_state);	
     }
-    return 0;
+    return 1;
+    
 }


### PR DESCRIPTION
Elevator initialization has been moved from main to the "start" state which has been renamed to "initialize". "Exit" is now part of the state enum, and the while loop in main now checks for "exit".
Also minor cosmetic changes.